### PR TITLE
cypress add set subset for creation task from project origin

### DIFF
--- a/cvat-ui/src/components/create-task-page/project-subset-field.tsx
+++ b/cvat-ui/src/components/create-task-page/project-subset-field.tsx
@@ -63,7 +63,7 @@ export default function ProjectSubsetField(props: Props): JSX.Element {
         <Autocomplete
             value={internalValue}
             placeholder='Input subset'
-            className='cvat-project-search-field'
+            className='cvat-project-search-field cvat-project-subset-field'
             onSearch={(_value) => setInternalValue(_value)}
             onSelect={(_value) => {
                 if (_value !== internalValue) {

--- a/tests/cypress/integration/actions_projects_models/registration_involved/base_actions_project_task_user.js
+++ b/tests/cypress/integration/actions_projects_models/registration_involved/base_actions_project_task_user.js
@@ -42,7 +42,7 @@ context('Base actions on the project', () => {
     const emailAddr = `${userName}@local.local`;
     const password = 'GDrb41RguF!';
     let projectID = '';
-    const fromProject = true;
+    const projectSubsetFieldValue = 'Test';
 
     function getProjectID(projectName) {
         cy.contains('.cvat-project-name', projectName)
@@ -100,7 +100,7 @@ context('Base actions on the project', () => {
             );
             cy.goToProjectsList();
             cy.openProject(projectName);
-            cy.openTask(taskName.secondTask, fromProject);
+            cy.openTask(taskName.secondTask, projectSubsetFieldValue);
             cy.assignTaskToUser(Cypress.env('user'));
         });
         it('The task is successfully opened. No label editor on task page.', () => {

--- a/tests/cypress/integration/actions_projects_models/registration_involved/base_actions_project_task_user.js
+++ b/tests/cypress/integration/actions_projects_models/registration_involved/base_actions_project_task_user.js
@@ -42,6 +42,7 @@ context('Base actions on the project', () => {
     const emailAddr = `${userName}@local.local`;
     const password = 'GDrb41RguF!';
     let projectID = '';
+    const fromProject = true;
 
     function getProjectID(projectName) {
         cy.contains('.cvat-project-name', projectName)
@@ -99,7 +100,7 @@ context('Base actions on the project', () => {
             );
             cy.goToProjectsList();
             cy.openProject(projectName);
-            cy.openTask(taskName.secondTask);
+            cy.openTask(taskName.secondTask, fromProject);
             cy.assignTaskToUser(Cypress.env('user'));
         });
         it('The task is successfully opened. No label editor on task page.', () => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -11,7 +11,6 @@ require('cypress-localstorage-commands');
 require('../plugins/compareImages/compareImagesCommand');
 
 let selectedValueGlobal = '';
-const projectSubsetFieldValue = 'Test';
 
 Cypress.Commands.add('login', (username = Cypress.env('user'), password = Cypress.env('password')) => {
     cy.get('[placeholder="Username"]').type(username);
@@ -144,6 +143,7 @@ Cypress.Commands.add(
         attachToProject = false,
         projectName,
         expectedResult = 'success',
+        projectSubsetFieldValue = 'Test',
     ) => {
         cy.get('#cvat-create-task-button').click({ force: true });
         cy.url().should('include', '/tasks/create');
@@ -193,10 +193,10 @@ Cypress.Commands.add(
     },
 );
 
-Cypress.Commands.add('openTask', (taskName, fromProject) => {
+Cypress.Commands.add('openTask', (taskName, projectSubsetFieldValue) => {
     cy.contains('strong', taskName).parents('.cvat-tasks-list-item').contains('a', 'Open').click({ force: true });
     cy.get('.cvat-task-details').should('exist');
-    if (fromProject) {
+    if (projectSubsetFieldValue) {
         cy.get('.cvat-project-subset-field').find('input').should('have.attr', 'value', projectSubsetFieldValue);
     }
 });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -11,6 +11,7 @@ require('cypress-localstorage-commands');
 require('../plugins/compareImages/compareImagesCommand');
 
 let selectedValueGlobal = '';
+const projectSubsetFieldValue = 'Test';
 
 Cypress.Commands.add('login', (username = Cypress.env('user'), password = Cypress.env('password')) => {
     cy.get('[placeholder="Username"]').type(username);
@@ -171,6 +172,7 @@ Cypress.Commands.add(
             cy.get('.cvat-project-search-field').within(() => {
                 cy.get('[type="search"]').should('have.value', projectName);
             });
+            cy.get('.cvat-project-subset-field').type(projectSubsetFieldValue);
             cy.get('.cvat-constructor-viewer-new-item').should('not.exist');
         }
         cy.get('input[type="file"]').attachFile(image, { subjectType: 'drag-n-drop' });
@@ -191,9 +193,12 @@ Cypress.Commands.add(
     },
 );
 
-Cypress.Commands.add('openTask', (taskName) => {
+Cypress.Commands.add('openTask', (taskName, fromProject) => {
     cy.contains('strong', taskName).parents('.cvat-tasks-list-item').contains('a', 'Open').click({ force: true });
     cy.get('.cvat-task-details').should('exist');
+    if (fromProject) {
+        cy.get('.cvat-project-subset-field').find('input').should('have.attr', 'value', projectSubsetFieldValue);
+    }
 });
 
 Cypress.Commands.add('saveJob', (method = 'PATCH', status = 200, as = 'saveJob') => {


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
