### PR TITLE
Added test for "Rotated bounding boxes"

### DIFF
--- a/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
+++ b/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
@@ -29,7 +29,7 @@ context('Rotated bounding boxes.', () => {
 
     const transformMatrixShape = [];
 
-    function testShapeRorate(shape, x, y, expectedRorate, shift) {
+    function testShapeRotate(shape, x, y, expectedRorate, shift) {
         cy.get(shape)
             .trigger('mousemove')
             .trigger('mouseover')
@@ -60,8 +60,8 @@ context('Rotated bounding boxes.', () => {
 
     describe(`Testing case "${caseId}"`, () => {
         it('Check that bounding boxes can be rotated.', () => {
-            testShapeRorate('#cvat_canvas_shape_1', 350, 150, '11.4°');
-            testShapeRorate('#cvat_canvas_shape_2', 350, 150, '26.6°');
+            testShapeRotate('#cvat_canvas_shape_1', 350, 150, '11.4°');
+            testShapeRotate('#cvat_canvas_shape_2', 350, 150, '26.6°');
             cy.get('#cvat_canvas_shape_2').then((shape2) => {
                 const shapeAttrs = shape2.attr('transform').split('(')[1].split(')')[0].split(',');
                 for (const i of shapeAttrs) {
@@ -88,7 +88,7 @@ context('Rotated bounding boxes.', () => {
             cy.get('#cvat_canvas_shape_2').click();
             cy.get('body').type('m');
 
-            testShapeRorate('#cvat_canvas_shape_2', 350, 250, '91.9°');
+            testShapeRotate('#cvat_canvas_shape_2', 350, 250, '91.9°');
 
             // Comparison of the values of the shape attribute of the current frame with the previous frame
             for (let frame = 8; frame >= 1; frame--) {
@@ -122,8 +122,8 @@ context('Rotated bounding boxes.', () => {
 
         it('Check rotation with hold Shift button.', () => {
             cy.goCheckFrameNumber(0);
-            testShapeRorate('#cvat_canvas_shape_1', 350, 150, '13.0°', true);
-            testShapeRorate('#cvat_canvas_shape_1', 350, 180, '14.2°', true);
+            testShapeRotate('#cvat_canvas_shape_1', 350, 150, '13.0°', true);
+            testShapeRotate('#cvat_canvas_shape_1', 350, 180, '14.2°', true);
         });
     });
 });

--- a/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
+++ b/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
@@ -1,0 +1,103 @@
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { labelName, taskName } from '../../support/const';
+
+context('Rotated bounding boxes.', () => {
+    const caseId = '108';
+    const createRectangleShape2Points = {
+        points: 'By 2 Points',
+        type: 'Shape',
+        labelName,
+        firstX: 250,
+        firstY: 350,
+        secondX: 350,
+        secondY: 450,
+    };
+    const createRectangleTrack2Points = {
+        points: 'By 2 Points',
+        type: 'Track',
+        labelName,
+        firstX: createRectangleShape2Points.firstX,
+        firstY: createRectangleShape2Points.firstY - 150,
+        secondX: createRectangleShape2Points.secondX,
+        secondY: createRectangleShape2Points.secondY - 150,
+    };
+
+    let transformMatrixShape;
+
+    function testShapeRorate(shape, x, y, expectedRorate, shift) {
+        cy.get(shape)
+            .trigger('mousemove')
+            .trigger('mouseover')
+            .should('have.class', 'cvat_canvas_shape_activated');
+        cy.get('.svg_select_points_rot')
+            .should('be.visible')
+            .and('have.length', 1)
+            .trigger('mousemove')
+            .trigger('mouseover')
+            .trigger('mousedown', { button: 0 });
+        if (shift) {
+            cy.get('.cvat-canvas-container').trigger('mousemove', x, y, { shiftKey: true });
+        } else {
+            cy.get('.cvat-canvas-container').trigger('mousemove', x, y);
+        }
+        cy.get('#cvat_canvas_text_content').should('contain.text', expectedRorate);
+        cy.get('.cvat-canvas-container').trigger('mouseup');
+        cy.get(shape).should('have.attr', 'transform');
+    }
+
+    before(() => {
+        cy.openTask(taskName);
+        cy.openJob();
+        Cypress.config('scrollBehavior', false);
+        cy.createRectangle(createRectangleShape2Points);
+        cy.createRectangle(createRectangleTrack2Points);
+    });
+
+    describe(`Testing case "${caseId}"`, () => {
+        it('Check that bounding boxes can be rotated.', () => {
+            testShapeRorate('#cvat_canvas_shape_1', 350, 150, '11.4°');
+            testShapeRorate('#cvat_canvas_shape_2', 350, 150, '26.6°');
+            cy.get('#cvat_canvas_shape_2').then((shape2) => {
+                transformMatrixShape = shape2.attr('transform');
+            });
+        });
+
+        it('Check interpolation, merging/splitting rotated shapes.', () => {
+            // Check track roration on all frames
+            for (let frame = 1; frame < 10; frame++) {
+                cy.goToNextFrame(frame);
+                cy.get('#cvat_canvas_shape_2').should('have.attr', 'transform', transformMatrixShape);
+            }
+            // Merge tracks
+            cy.get('.cvat-merge-control').click();
+            cy.get('#cvat_canvas_shape_2').click();
+            cy.get('body').type('m');
+
+            testShapeRorate('#cvat_canvas_shape_2', 350, 250, '91.9°');
+
+            for (let frame = 8; frame >= 1; frame--) {
+                cy.goToPreviousFrame(frame);
+                cy.get('#cvat_canvas_shape_2').should('have.attr', 'transform').and('not.equal', transformMatrixShape);
+            }
+            cy.goCheckFrameNumber(2);
+
+            // Split tracks
+            cy.get('.cvat-split-track-control').click();
+            // A single click does not reproduce the split a track scenario in cypress test.
+            cy.get('#cvat_canvas_shape_2').click().click();
+            cy.get('#cvat_canvas_shape_3').should('have.attr', 'transform').then((shapeTranform) => {
+                cy.get('#cvat_canvas_shape_4').should('have.attr', 'transform', shapeTranform);
+            });
+        });
+
+        it('Check rotation with hold Shift button.', () => {
+            cy.goCheckFrameNumber(0);
+            testShapeRorate('#cvat_canvas_shape_1', 350, 150, '13.0°', true);
+        });
+    });
+});

--- a/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
+++ b/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
@@ -29,7 +29,7 @@ context('Rotated bounding boxes.', () => {
 
     const transformMatrixShape = [];
 
-    function testShapeRotate(shape, x, y, expectedRorate, shift) {
+    function testShapeRotate(shape, x, y, expectedRotate, pressShift) {
         cy.get(shape)
             .trigger('mousemove')
             .trigger('mouseover')
@@ -38,16 +38,36 @@ context('Rotated bounding boxes.', () => {
             .should('be.visible')
             .and('have.length', 1)
             .trigger('mousemove')
-            .trigger('mouseover')
-            .trigger('mousedown', { button: 0 });
-        if (shift) {
-            cy.get('.cvat-canvas-container').trigger('mousemove', x, y, { shiftKey: true });
-        } else {
-            cy.get('.cvat-canvas-container').trigger('mousemove', x, y);
+            .trigger('mouseover');
+        if (pressShift) {
+            cy.get('body').type('{shift}', { release: false });
         }
-        cy.get('#cvat_canvas_text_content').should('contain.text', expectedRorate);
+        cy.get('.svg_select_points_rot').trigger('mousedown', { button: 0 });
+        cy.get('.cvat-canvas-container').trigger('mousemove', x, y);
+        cy.get('#cvat_canvas_text_content').should('contain.text', expectedRotate);
         cy.get('.cvat-canvas-container').trigger('mouseup');
         cy.get(shape).should('have.attr', 'transform');
+    }
+
+    function testCompareRotate(shape, toFrame) {
+        for (let frame = 8; frame >= toFrame; frame--) {
+            cy.get(shape).should('have.attr', 'transform').then(($transform) => {
+                const transform = $transform.split('(')[1].split(')')[0].split(',');
+                const transformMatrix = [];
+                for (const i of transform) {
+                    transformMatrix.push(Number(i).toFixed(3));
+                }
+                cy.goToPreviousFrame(frame);
+                cy.get(shape).should('have.attr', 'transform').then(($transform2) => {
+                    const transform2 = $transform2.split('(')[1].split(')')[0].split(',');
+                    const transformMatrix2 = [];
+                    for (const i of transform2) {
+                        transformMatrix2.push(Number(i).toFixed(3));
+                    }
+                    expect(transformMatrix).not.deep.eq(transformMatrix2);
+                });
+            });
+        }
     }
 
     before(() => {
@@ -56,6 +76,9 @@ context('Rotated bounding boxes.', () => {
         Cypress.config('scrollBehavior', false);
         cy.createRectangle(createRectangleShape2Points);
         cy.createRectangle(createRectangleTrack2Points);
+        cy.goCheckFrameNumber(1);
+        cy.createRectangle(createRectangleShape2Points);
+        cy.goCheckFrameNumber(0);
     });
 
     describe(`Testing case "${caseId}"`, () => {
@@ -83,47 +106,49 @@ context('Rotated bounding boxes.', () => {
                     expect(transformMatrix).to.deep.eq(transformMatrixShape);
                 });
             }
-            // Merge tracks
-            cy.get('.cvat-merge-control').click();
-            cy.get('#cvat_canvas_shape_2').click();
-            cy.get('body').type('m');
 
             testShapeRotate('#cvat_canvas_shape_2', 350, 250, '91.9°');
 
             // Comparison of the values of the shape attribute of the current frame with the previous frame
-            for (let frame = 8; frame >= 1; frame--) {
-                cy.get('#cvat_canvas_shape_2').should('have.attr', 'transform').then(($transform) => {
-                    const transform = $transform.split('(')[1].split(')')[0].split(',');
-                    const transformMatrix = [];
-                    for (const i of transform) {
-                        transformMatrix.push(Number(i).toFixed(3));
-                    }
-                    cy.goToPreviousFrame(frame);
-                    cy.get('#cvat_canvas_shape_2').should('have.attr', 'transform').then(($transform2) => {
-                        const transform2 = $transform2.split('(')[1].split(')')[0].split(',');
-                        const transformMatrix2 = [];
-                        for (const i of transform2) {
-                            transformMatrix2.push(Number(i).toFixed(3));
-                        }
-                        expect(transformMatrix).not.deep.eq(transformMatrix2);
-                    });
-                });
-            }
-            cy.goCheckFrameNumber(2);
+            testCompareRotate('#cvat_canvas_shape_2', 0);
 
+            // Merge shapes
+            cy.goCheckFrameNumber(0);
+            cy.get('.cvat-merge-control').click();
+            cy.get('#cvat_canvas_shape_1').click();
+            cy.goCheckFrameNumber(1);
+            cy.get('#cvat_canvas_shape_3').click();
+            cy.get('body').type('m');
+            cy.goCheckFrameNumber(2);
+            cy.get('#cvat_canvas_shape_4').should('be.hidden');
+            cy.get('#cvat-objects-sidebar-state-item-4')
+                .should('contain', '4')
+                .and('contain', 'RECTANGLE TRACK')
+                .within(() => {
+                    cy.get('.cvat-object-item-button-keyframe').click();
+                    cy.get('.cvat-object-item-button-keyframe-enabled').should('not.exist');
+                });
+            cy.get('#cvat_canvas_shape_4').should('be.visible');
+            cy.goCheckFrameNumber(9);
+            testShapeRotate('#cvat_canvas_shape_4', 350, 250, '18.5°');
+
+            // Comparison of the values of the shape attribute of the current frame with the previous frame
+            testCompareRotate('#cvat_canvas_shape_4', 2);
+
+            cy.goCheckFrameNumber(3);
             // Split tracks
             cy.get('.cvat-split-track-control').click();
             // A single click does not reproduce the split a track scenario in cypress test.
             cy.get('#cvat_canvas_shape_2').click().click();
-            cy.get('#cvat_canvas_shape_3').should('have.attr', 'transform').then((shapeTransform) => {
-                cy.get('#cvat_canvas_shape_4').should('have.attr', 'transform', shapeTransform);
+            cy.get('#cvat_canvas_shape_5').should('have.attr', 'transform').then((shapeTransform) => {
+                cy.get('#cvat_canvas_shape_6').should('have.attr', 'transform', shapeTransform);
             });
         });
 
         it('Check rotation with hold Shift button.', () => {
             cy.goCheckFrameNumber(0);
-            testShapeRotate('#cvat_canvas_shape_1', 350, 150, '13.0°', true);
-            testShapeRotate('#cvat_canvas_shape_1', 350, 180, '14.2°', true);
+            testShapeRotate('#cvat_canvas_shape_4', 350, 150, '15.0°', true);
+            testShapeRotate('#cvat_canvas_shape_4', 400, 150, '30.0°', true);
         });
     });
 });


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
